### PR TITLE
bugfix/remove-cron-docs

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -4,11 +4,6 @@ on:
   push:
     branches:
       - master
-  schedule:
-    # <minute [0,59]> <hour [0,23]> <day of the month [1,31]> <month of the year [1,12]> <day of the week [0,6]>
-    # https://pubs.opengroup.org/onlinepubs/9699919799/utilities/crontab.html#tag_20_25_07
-    # Run every Monday at 18:00:00 UTC (Monday at 10:00:00 PST)
-    - cron: '0 18 * * 1'
 
 jobs:
   docs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Test and Lint
+name: Test
 
 on: pull_request
 
@@ -24,20 +24,3 @@ jobs:
     - name: Test with pytest
       run: |
         pytest --cov-report xml --cov=normal_mode_analysis normal_mode_analysis/tests/
-
-  lint:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v1
-    - name: Set up Python 3.7
-      uses: actions/setup-python@v1
-      with:
-        python-version: 3.7
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install .[test]
-    - name: Lint with flake8
-      run: |
-        flake8 normal_mode_analysis --count --verbose --max-line-length=127 --show-source --statistics


### PR DESCRIPTION
**Pull request recommendations:**
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_
- [x] Provide context of changes.
  This was the first time any of the cookiecutter builds ran on a schedule because we finally fixed the CRON string for them all. `aicsimageio` and your repo's docs failed to build on those tasks and I think it's because they can't be built and pushed on CRON because there are no new differences between current docs and newly generated docs. (Why git push when no commit diff basically).

  This removes the CRON from doc building, and because your lint task was failing and we discussed it, this also removes the lint task.

- [x] Provide relevant tests for your feature or bug fix.
- [x] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
