### PR TITLE
Remove lint from build master workflow

### DIFF
--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -32,20 +32,3 @@ jobs:
     - name: Test with pytest
       run: |
         pytest --cov-report xml --cov=normal_mode_analysis normal_mode_analysis/tests/
-
-  lint:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v1
-    - name: Set up Python 3.7
-      uses: actions/setup-python@v1
-      with:
-        python-version: 3.7
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install .[test]
-    - name: Lint with flake8
-      run: |
-        flake8 normal_mode_analysis --count --verbose --max-line-length=127 --show-source --statistics


### PR DESCRIPTION
Forgot to remove the lint task from `build-master`
