### PR TITLE
Fix auto documentation generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,6 @@ gen-docs: ## generate Sphinx HTML documentation, including API docs
 	rm -f docs/normal_mode_analysis*.rst
 	rm -f docs/modules.rst
 	sphinx-apidoc -o docs/ normal_mode_analysis **/tests/
-	$(MAKE) -C docs clean
 	$(MAKE) -C docs html
 
 docs: ## generate Sphinx HTML documentation, including API docs, and serve to browser


### PR DESCRIPTION
We found a bug in auto documentation generation. The way GitHub actions works is they are pulled from other repos so the actual task is already fixed but there is a side effect here which is removing the cleaning operation prior to running documentation generation. From all our testing, the cleaning operation wasn't doing anything anyway so there should be no side effects only a bugfix :)